### PR TITLE
Don't blow away existing options

### DIFF
--- a/eclipse-external-annotations-m2e-plugin.core/src/org/lastnpe/m2e/core/configurator/ClasspathConfigurator.java
+++ b/eclipse-external-annotations-m2e-plugin.core/src/org/lastnpe/m2e/core/configurator/ClasspathConfigurator.java
@@ -450,7 +450,9 @@ public class ClasspathConfigurator extends AbstractProjectConfigurator implement
         if (javaProject == null) {
             return;
         }
-        javaProject.setOptions(fromProperties(configurationCompilerArgumentsProperties));
+        Map<String, String> options = javaProject.getOptions(false);
+        options.putAll(fromProperties(configurationCompilerArgumentsProperties));
+        javaProject.setOptions(options);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
Other parts of m2e configure options, like JDK compliance, in the same file, so the additional options here should be merged with them.